### PR TITLE
Pin Docker `:latest` image tags to digest - mucles demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest AS builder
+FROM golang:latest@sha256:f38c7f7bbaca5d664e39cd982a1cb5b6f8e999244e9ddb6ec8ba098438b3f4da AS builder
 
 WORKDIR /src
 COPY . .


### PR DESCRIPTION
The `:latest` tag changes, so future pulls of this image may retrieve a different image with different (and possibly erroneous, unexpected, or dangerous) behavior. Pin the image to an [image digest](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier) for deterministic behavior. *See also: [Hadolint error DL3007](https://github.com/hadolint/hadolint/wiki/DL3007).*

[_Created by Sourcegraph batch change `manuel/pin-docker-images`._](https://demo.sourcegraph.com/users/manuel/batch-changes/pin-docker-images)