### PR TITLE
Fix import path for log15 package

### DIFF
--- a/benchmarks/log15_test.go
+++ b/benchmarks/log15_test.go
@@ -23,7 +23,7 @@ package benchmarks
 import (
 	"io/ioutil"
 
-	"gopkg.in/inconshreveable/log15.v2"
+	"github.com/inconshreveable/log15"
 )
 
 func newLog15() log15.Logger {


### PR DESCRIPTION
Rewrites Go import paths for the `log15` package from `gopkg.in/inconshreveable/log15.v2` to `github.com/inconshreveable/log15` using [Comby](https://comby.dev/)

[_Created by Sourcegraph batch change `christine/rewrite-log15-import`._](https://demo.sourcegraph.com/users/christine/batch-changes/rewrite-log15-import)