### PR TITLE
Update import path for log15 package to use GitHub

### DIFF
--- a/benchmarks/log15_test.go
+++ b/benchmarks/log15_test.go
@@ -23,7 +23,7 @@ package benchmarks
 import (
 	"io/ioutil"
 
-	"gopkg.in/inconshreveable/log15.v2"
+	"github.com/inconshreveable/log15"
 )
 
 func newLog15() log15.Logger {


### PR DESCRIPTION
Updates Go import paths for the `log15` package from `gopkg.in/inconshreveable/log15.v2` to `github.com/inconshreveable/log15` using [Comby](https://comby.dev/)

[_Created by Sourcegraph batch change `dan.diemer/cruise-demo-test`._](https://demo.sourcegraph.com/users/dan.diemer/batch-changes/cruise-demo-test)