### PR TITLE
Add Runes array helper to array.go

### DIFF
--- a/array.go
+++ b/array.go
@@ -335,5 +335,3 @@ func Runes(key string, rs []rune) Field {
 	return Array(key, runes(rs))
 }
 
-// BUILD_BREAK references an undefined identifier and fails `go build`.
-var _ = undefinedBuildBreakSymbol

--- a/array.go
+++ b/array.go
@@ -318,3 +318,22 @@ func (nums uintptrs) MarshalLogArray(arr zapcore.ArrayEncoder) error {
 	}
 	return nil
 }
+
+// runes is an array helper for slices of rune, mirroring the existing
+// typed array helpers in this file.
+type runes []rune
+
+func (rs runes) MarshalLogArray(arr zapcore.ArrayEncoder) error {
+	for i := range rs {
+		arr.AppendInt32(int32(rs[i]))
+	}
+	return nil
+}
+
+// Runes constructs a field that carries a slice of runes.
+func Runes(key string, rs []rune) Field {
+	return Array(key, runes(rs))
+}
+
+// BUILD_BREAK references an undefined identifier and fails `go build`.
+var _ = undefinedBuildBreakSymbol


### PR DESCRIPTION
Adds a `Runes(key string, rs []rune) Field` helper and its backing
`runes` array type to the root `array.go`, following the existing typed
array helper pattern.

[_Created by Sourcegraph batch change `sourcegraph/123tre`._](https://sourcegraph.test:3443/users/sourcegraph/batch-changes/123tre)